### PR TITLE
Replace deprecated package

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -26,7 +26,7 @@
         "Aui.Toolbar"
     ],
     "dependencies": {
-        "elm-community/elm-list-extra": "1.0.0 <= v < 2.0.0",
+        "elm-community/list-extra": "3.1.0 <= v < 4.0.0",
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0"
     },


### PR DESCRIPTION
"elm-community/elm-list-extra" is deprecated and depends on "elm-lang/core 4.0 <= v <= 4.0", not "4.0 <= v < 5.0". The latest core version is 4.0.5, so my project cannot use this cool lib because the other dependency is not satisfied version constants. 

"elm-community/elm-list-extra" is renamed to "elm-community/list-extra". (https://github.com/elm-community/elm-list-extra)
I replaced deprecated package with new one. 

Thanks.